### PR TITLE
Markup for SINCE

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -5,9 +5,6 @@
  * https://github.com/fedwiki/wiki-plugin-activity/blob/master/LICENSE.txt
 ###
 
-since = 0
-listing = []
-errors = 0
 
 escape = (line) ->
   line
@@ -15,40 +12,39 @@ escape = (line) ->
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
 
-parse = (text) ->
-  listing = []
-  errors = 0
-  for line in text.split /\r?\n/
-    continue unless words = line.match /\S+/g
-    # switch words[0]
-    #   when 'SINCE' then since = +(words[1] || 1)
-    html = escape line
-    try
-      [match, op, arg] = line.match(/^\s*(\w*)\s*(.*)$/)
-      switch op
-        when '' then
-        when 'SINCE'
-          if match = arg.match /^(\d+) hours?$/i
-            since = Date.now() - ((+match[1])*1000*60*60)
-          else if match = arg.match /^(\d+) days?$/i
-            since = Date.now() - ((+match[1])*1000*60*60*24)
-          else if match = arg.match /^(\d+) weeks?$/i
-            since = Date.now() - ((+match[1])*1000*60*60*24*7)
-          else if arg.match /^(sun|mon|tue|wed|thu|fri|sat)$/i
-            since = ((new Date).getDay()+7-2)%7
-          else throw {message:"don't know SINCE '#{arg}' argument"}
-        when /SINCE (mon|tue|wed|thr|fri|sat|sun)/
-        else throw {message:"don't know '#{op}' command"}
-    catch err
-      errors++
-      html = """<span style="background-color:#fdd;width:100%;" title="#{err.message}">#{html}</span>"""
-    listing.push html
-
-
 emit = ($item, item) ->
-  parse item.text || ''
 
 bind = ($item, item) ->
+
+  parse = (text) ->
+    listing = []
+    errors = 0
+    for line in text.split /\r?\n/
+      continue unless words = line.match /\S+/g
+      # switch words[0]
+      #   when 'SINCE' then since = +(words[1] || 1)
+      html = escape line
+      try
+        [match, op, arg] = line.match(/^\s*(\w*)\s*(.*)$/)
+        switch op
+          when '' then
+          when 'SINCE'
+            if match = arg.match /^(\d+) hours?$/i
+              since = Date.now() - ((+match[1])*1000*60*60)
+            else if match = arg.match /^(\d+) days?$/i
+              since = Date.now() - ((+match[1])*1000*60*60*24)
+            else if match = arg.match /^(\d+) weeks?$/i
+              since = Date.now() - ((+match[1])*1000*60*60*24*7)
+            else if arg.match /^(sun|mon|tue|wed|thu|fri|sat)$/i
+              since = ((new Date).getDay()+7-2)%7
+            else throw {message:"don't know SINCE '#{arg}' argument"}
+          when /SINCE (mon|tue|wed|thr|fri|sat|sun)/
+          else throw {message:"don't know '#{op}' command"}
+      catch err
+        errors++
+        html = """<span style="background-color:#fdd;width:100%;" title="#{err.message}">#{html}</span>"""
+      console.log "in parse: "+ since
+      listing.push html
 
   display = (pages) ->
     $item.empty()
@@ -97,6 +93,13 @@ bind = ($item, item) ->
       """
     $item.append "<p><i>#{omitted} more older titles</i></p>" if omitted > 0
 
+  since = 0
+  listing = []
+  errors = 0
+
+  parse item.text || ''
+  console.log "back from parser: "+since
+
   omitted = 0
   merge = (neighborhood) ->
     pages = {}
@@ -130,4 +133,3 @@ bind = ($item, item) ->
 
 window.plugins.activity = {emit, bind} if window?
 module.exports = {} if module?
-

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -44,7 +44,10 @@ bind = ($item, item) ->
             else if match = arg.match /^(sun|mon|tue|wed|thu|fri|sat).*$/i
               days = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
               since = todayStart - ((((new Date).getDay() + 7 - (days.indexOf(match[1].toLowerCase())))%7) * 1000*60*60*24)
-            else throw {message:"don't know SINCE '#{arg}' argument"}
+            else if !(isNaN(Date.parse(arg)))
+              since = Date.parse(arg)
+            else
+              throw {message:"don't know SINCE '#{arg}' argument"}
           else throw {message:"don't know '#{op}' command"}
       catch err
         errors++
@@ -102,7 +105,7 @@ bind = ($item, item) ->
   parse item.text || ''
 
   omitted = 0
-  
+
   merge = (neighborhood) ->
     pages = {}
     for site, map of neighborhood

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -134,7 +134,6 @@ bind = ($item, item) ->
 
   $item.dblclick -> wiki.textEditor $item, item
 
-  console.log 'since : ', (new Date(since)).toString()
 
 window.plugins.activity = {emit, bind} if window?
 module.exports = {} if module?

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -59,7 +59,7 @@ bind = ($item, item) ->
     if errors
       $item.append listing
       return
-    $item.append "<h3>Activity Since #{(new Date(since)).toDateString()}</h3>" if since
+    $item.append "<h2>Activity Since #{(new Date(since)).toDateString()}</h2>" if since
     now = (new Date).getTime();
     sections = [
       {date: now-1000*60*60*24*365, period: 'Years'}

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -92,7 +92,7 @@ bind = ($item, item) ->
           href="/#{sites[0].page.slug}"
           data-page-name="#{sites[0].page.slug}"
           title="#{context}">
-          #{sites[0].page.title || sites[0].page.slug}
+          #{escape(sites[0].page.title || sites[0].page.slug)}
         </a><br>
       """
     $item.append "<p><i>#{omitted} more older titles</i></p>" if omitted > 0

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -41,7 +41,7 @@ bind = ($item, item) ->
               since = Date.now() - ((+match[1])*1000*60*60*24)
             else if match = arg.match /^(\d+) weeks?$/i
               since = Date.now() - ((+match[1])*1000*60*60*24*7)
-            else if match = arg.match /^(sun|mon|tue|wed|thu|fri|sat).*$/i
+            else if match = arg.match /^(sun|mon|tue|wed|thu|fri|sat)[a-z]*$/i
               days = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"]
               since = todayStart - ((((new Date).getDay() + 7 - (days.indexOf(match[1].toLowerCase())))%7) * 1000*60*60*24)
             else if !(isNaN(Date.parse(arg)))

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -16,6 +16,10 @@ emit = ($item, item) ->
 
 bind = ($item, item) ->
 
+  since = 0
+  listing = []
+  errors = 0
+
   parse = (text) ->
     listing = []
     errors = 0
@@ -93,9 +97,7 @@ bind = ($item, item) ->
       """
     $item.append "<p><i>#{omitted} more older titles</i></p>" if omitted > 0
 
-  since = 0
-  listing = []
-  errors = 0
+
 
   parse item.text || ''
   console.log "back from parser: "+since

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -5,71 +5,129 @@
  * https://github.com/fedwiki/wiki-plugin-activity/blob/master/LICENSE.txt
 ###
 
-window.plugins.activity =
-  emit: ($item, item) ->
-  bind: ($item, item) ->
+since = 0
+listing = []
+errors = 0
 
-    display = (pages) ->
-      now = (new Date).getTime();
-      sections = [
-        {date: now-1000*60*60*24*365, period: 'Years'}
-        {date: now-1000*60*60*24*91, period: 'a Year'}
-        {date: now-1000*60*60*24*31, period: 'a Season'}
-        {date: now-1000*60*60*24*7, period: 'a Month'}
-        {date: now-1000*60*60*24, period: 'a Week'}
-        {date: now-1000*60*60, period: 'a Day'}
-        {date: now-1000*60, period: 'an Hour'}
-        {date: now-1000, period: 'a Minute'}
-        {date: now, period: 'Seconds'}
-      ]
-      $item.empty()
-      bigger = now
-      for sites in pages
-        smaller = sites[0].page.date
-        for section in sections
-          if section.date > smaller and section.date < bigger
-            $item.append """
-              <h3> Within #{section.period} </h3>
-            """
-            break
-        bigger = smaller
-        for each, i in sites
-          joint = if sites[i+1]?.page.date == each.page.date then "" else "&nbsp"
+escape = (line) ->
+  line
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+
+parse = (text) ->
+  listing = []
+  errors = 0
+  for line in text.split /\r?\n/
+    continue unless words = line.match /\S+/g
+    # switch words[0]
+    #   when 'SINCE' then since = +(words[1] || 1)
+    html = escape line
+    try
+      [match, op, arg] = line.match(/^\s*(\w*)\s*(.*)$/)
+      switch op
+        when '' then
+        when 'SINCE'
+          if match = arg.match /^(\d+) hours?$/i
+            since = Date.now() - ((+match[1])*1000*60*60)
+          else if match = arg.match /^(\d+) days?$/i
+            since = Date.now() - ((+match[1])*1000*60*60*24)
+          else if match = arg.match /^(\d+) weeks?$/i
+            since = Date.now() - ((+match[1])*1000*60*60*24*7)
+          else if arg.match /^(sun|mon|tue|wed|thu|fri|sat)$/i
+            since = ((new Date).getDay()+7-2)%7
+          else throw {message:"don't know SINCE '#{arg}' argument"}
+        when /SINCE (mon|tue|wed|thr|fri|sat|sun)/
+        else throw {message:"don't know '#{op}' command"}
+    catch err
+      errors++
+      html = """<span style="background-color:#fdd;width:100%;" title="#{err.message}">#{html}</span>"""
+    listing.push html
+
+
+emit = ($item, item) ->
+  parse item.text || ''
+
+bind = ($item, item) ->
+
+  display = (pages) ->
+    $item.empty()
+    if errors
+      $item.append listing
+      return
+    now = (new Date).getTime();
+    sections = [
+      {date: now-1000*60*60*24*365, period: 'Years'}
+      {date: now-1000*60*60*24*91, period: 'a Year'}
+      {date: now-1000*60*60*24*31, period: 'a Season'}
+      {date: now-1000*60*60*24*7, period: 'a Month'}
+      {date: now-1000*60*60*24, period: 'a Week'}
+      {date: now-1000*60*60, period: 'a Day'}
+      {date: now-1000*60, period: 'an Hour'}
+      {date: now-1000, period: 'a Minute'}
+      {date: now, period: 'Seconds'}
+    ]
+    bigger = now
+    for sites in pages
+      smaller = sites[0].page.date
+      for section in sections
+        if section.date > smaller and section.date < bigger
           $item.append """
-            <img class="remote"
-              title="#{each.site}\n#{wiki.util.formatElapsedTime each.page.date}"
-              src="http://#{each.site}/favicon.png"
-              data-site="#{each.site}"
-              data-slug="#{each.page.slug}">#{joint}
+            <h3> Within #{section.period} </h3>
           """
-        context = if sites[0].site == location.host then "view" else "view => #{sites[0].site}"
+          break
+      bigger = smaller
+      for each, i in sites
+        joint = if sites[i+1]?.page.date == each.page.date then "" else "&nbsp"
         $item.append """
-          <a class="internal"
-            href="/#{sites[0].page.slug}"
-            data-page-name="#{sites[0].page.slug}"
-            title="#{context}">
-            #{sites[0].page.title || sites[0].page.slug}
-          </a><br>
+          <img class="remote"
+            title="#{each.site}\n#{wiki.util.formatElapsedTime each.page.date}"
+            src="http://#{each.site}/favicon.png"
+            data-site="#{each.site}"
+            data-slug="#{each.page.slug}">#{joint}
         """
+      context = if sites[0].site == location.host then "view" else "view => #{sites[0].site}"
+      $item.append """
+        <a class="internal"
+          href="/#{sites[0].page.slug}"
+          data-page-name="#{sites[0].page.slug}"
+          title="#{context}">
+          #{sites[0].page.title || sites[0].page.slug}
+        </a><br>
+      """
+    $item.append "<p><i>#{omitted} more older titles</i></p>" if omitted > 0
+
+  omitted = 0
+  merge = (neighborhood) ->
+    pages = {}
+    for site, map of neighborhood
+      continue if map.sitemapRequestInflight or !(map.sitemap?)
+      for each in map.sitemap
+        sites = pages[each.slug]
+        pages[each.slug] = sites = [] unless sites?
+        sites.push {site: site, page: each}
+    for slug, sites of pages
+      sites.sort (a, b) ->
+        (b.page.date || 0) - (a.page.date || 0)
+    pages = (sites for slug, sites of pages)
+    pages.sort (a, b) ->
+        (b[0].page.date || 0) - (a[0].page.date || 0)
+
+    omitted = 0
+    pages.filter (e) ->
+      omitted += 1 if e[0].page.date <= since
+      e[0].page.date > since
 
 
-    merge = (neighborhood) ->
-      pages = {}
-      for site, map of neighborhood
-        continue if map.sitemapRequestInflight or !(map.sitemap?)
-        for each in map.sitemap
-          sites = pages[each.slug]
-          pages[each.slug] = sites = [] unless sites?
-          sites.push {site: site, page: each}
-      for slug, sites of pages
-        sites.sort (a, b) ->
-          (b.page.date || 0) - (a.page.date || 0)
-      pages = (sites for slug, sites of pages)
-      pages.sort (a, b) ->
-          (b[0].page.date || 0) - (a[0].page.date || 0)
-      pages
+  display merge wiki.neighborhood
 
+  $('body').on 'new-neighbor-done', (e, site) ->
     display merge wiki.neighborhood
 
-    $('body').on 'new-neighbor-done', (e, site) ->
-      display merge wiki.neighborhood
+  $item.dblclick -> wiki.textEditor $item, item
+
+  console.log 'since', since
+
+window.plugins.activity = {emit, bind} if window?
+module.exports = {} if module?
+


### PR DESCRIPTION
Ward and myself made a start on adding support for the idea in #4.

A number of syntaxes are supported:
```
SINCE n hour
SINCE n day
SINCE n week 
```
where n is a positive integer, and also accepts hours, days, or weeks.

```
SINCE dayname
```
where dayname is one of mon, tue, wed, thu, fri, sat, or sun

```
SINCE date
```
where date is a RFC2822 or ISO 8601 date - so dates like `Dec 25, 1995` and `25 Dec 1995` are supported.

A heading is added at the start of the plug-in content to provide feedback about when the displayed activity is since.