### PR TITLE
Adding support for more activity commands

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -87,12 +87,17 @@ bind = ($item, item) ->
     if errors
       $item.append listing
       return
-    header = "<heading>Page Activity"
+
+    header = ""
+    header += "<br/>searching for \"#{escape searchTerm}\"" if searchTerm
     header += "<br/>since #{(new Date(since)).toDateString()}" if since
     header += "<br/>more than #{twins} twins" if twins > 0
     header += "<br/>sorted by page title" if sortOrder is "title"
-    header += "<br/></heading>"
-    $item.append "#{header}"
+    header += "<br/>excluding neighborhood" if includeNeighbors is false
+
+    if header
+      $item.append "<p><b>Page Activity #{header}</b></p>"
+
     now = (new Date).getTime();
     sections = [
       {date: now-1000*60*60*24*365, period: 'Years'}

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -19,6 +19,7 @@ bind = ($item, item) ->
   since = 0
   listing = []
   errors = 0
+  includeNeighbors = true
 
   parse = (text) ->
     listing = []
@@ -48,6 +49,17 @@ bind = ($item, item) ->
               since = Date.parse(arg)
             else
               throw {message:"don't know SINCE '#{arg}' argument"}
+
+          when 'NEIGHBORHOOD'
+            if arg.match /^yes/i
+              console.log "Neighbors included"
+              includeNeighbors = true
+            else if arg.match /^no/i
+              console.log "Exclude neighbors"
+              includeNeighbors = false
+            else
+              throw {message:"don't know NEIGHBORHOOD '#{arg}' argument"}
+
           else throw {message:"don't know '#{op}' command"}
       catch err
         errors++
@@ -110,10 +122,11 @@ bind = ($item, item) ->
     pages = {}
     for site, map of neighborhood
       continue if map.sitemapRequestInflight or !(map.sitemap?)
-      for each in map.sitemap
-        sites = pages[each.slug]
-        pages[each.slug] = sites = [] unless sites?
-        sites.push {site: site, page: each}
+      if includeNeighbors or (!includeNeighbors and site == location.host)
+        for each in map.sitemap
+          sites = pages[each.slug]
+          pages[each.slug] = sites = [] unless sites?
+          sites.push {site: site, page: each}
     for slug, sites of pages
       sites.sort (a, b) ->
         (b.page.date || 0) - (a.page.date || 0)

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -87,15 +87,11 @@ bind = ($item, item) ->
     if errors
       $item.append listing
       return
-    header = "<heading> <h2>Page"
-    header += " activity since #{(new Date(since)).toDateString()}" if since
-    if twins > 0
-      if since
-        header += ",<br/>and "
-      else
-        header += "s "
-      header += "with more than #{twins} twins"
-    header += "</h2></heading>"
+    header = "<heading>Page Activity"
+    header += "<br/>since #{(new Date(since)).toDateString()}" if since
+    header += "<br/>more than #{twins} twins" if twins > 0
+    header += "<br/>sorted by page title" if sortOrder is "title"
+    header += "<br/></heading>"
     $item.append "#{header}"
     now = (new Date).getTime();
     sections = [


### PR DESCRIPTION
Adding support for more commands:

`NEIGHBORHOOD yes/no` adds the ability to exclude the current neighborhood, with will only really become useful once adding other sites via use of the roster data is added.

`TWINS n` adds the ability to only list activity for pages that have `n`, or more, twins.
