### PR TITLE
right justify labels

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -122,10 +122,10 @@ bind = ($item, item) ->
     for sites in pages
       if (sites.length >= twins) || twins == 0
         if sortOrder == "title"
-          smaller = sites[0].page.title.substr(0,1).toLowerCase()
+          smaller = sites[0].page.title.substr(0,1).toUpperCase()
           if smaller != bigger
             $item.append """
-              <b>#{smaller}</b><br>
+              <div style="width:100%; text-align:right;"><b>#{smaller}</b></span><br>
             """
         else
           smaller = sites[0].page.date


### PR DESCRIPTION
This could be just a matter of opinion. I'm thinking that the titles are easier to read when the sort labels are right justified.

![image](https://cloud.githubusercontent.com/assets/12127/6772458/f4bb7706-d0bb-11e4-9e99-03cc35882edb.png)
