### PR TITLE
disable sitemap updates while editing

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -205,7 +205,9 @@ bind = ($item, item) ->
       searchResults = wiki.neighborhoodObject.search(searchTerm)
     display merge wiki.neighborhood
 
-  $item.dblclick -> wiki.textEditor $item, item
+  $item.dblclick ->
+    $('body').off 'new-neighbor-done'
+    wiki.textEditor $item, item
 
 
 window.plugins.activity = {emit, bind} if window?


### PR DESCRIPTION
We disable sitemap updates while editing. Otherwise the dom update erases the editor but leaves double-click disabled so there is no getting back to the editor. We always update from available sitemaps when editing is finished so there is no reason to keep track up update events.