### PR TITLE
roster starting to work

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -25,6 +25,7 @@ bind = ($item, item) ->
   sortOrder = "date"
   searchTerm = ''
   searchResults = ''
+  rosterResults = {}
 
   parse = (text) ->
     listing = []
@@ -80,6 +81,19 @@ bind = ($item, item) ->
           when 'SEARCH'
             searchTerm = arg
             searchResults = wiki.neighborhoodObject.search(searchTerm)
+
+          when 'ROSTER'
+            includeNeighbors = false
+            items = $(".item:lt(#{$('.item').index($item)})")
+            sources = items.filter ".roster-source"
+            sources.each (i,source) ->
+              console.log 'source', source
+              roster = source.getRoster()
+              for key, value of roster
+                if key.toLowerCase().indexOf(arg.toLowerCase()) >= 0
+                  rosterResults[site] = true for site in value
+            console.log line, rosterResults
+
 
           else throw {message:"don't know '#{op}' command"}
       catch err
@@ -166,7 +180,7 @@ bind = ($item, item) ->
     pages = {}
     for site, map of neighborhood
       continue if map.sitemapRequestInflight or !(map.sitemap?)
-      if includeNeighbors or (!includeNeighbors and site == location.host)
+      if includeNeighbors or site == location.host or rosterResults[site]
         for each in map.sitemap
           sites = pages[each.slug]
           pages[each.slug] = sites = [] unless sites?


### PR DESCRIPTION
This pull request is ready for testing but I'm not yet happy with how it works. Not yet time to merge.

I've followed the plan I posted in #4. This anticipated some command interactions but not all.

When I set out to see specific activity in specific rosters I still see activity in the origin. There is not yet a way to turn this site (site == location.host) off. Should there be? I think yes. But maybe commands should be at a higher level and reported as such in the heading. I don't have a specific proposal here yet. I'm just thinking this is more complicated than need be already and it doesn't yet do what one would expect.