### PR TITLE
reverse the page order for conversatons

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -221,7 +221,7 @@ bind = ($item, item) ->
 
         if query.conversation
           conversationLink = ''
-          for each, i in sites
+          for each, i in sites.slice().reverse()
             conversationLink += "/#{each.site}/#{each.page.slug}"
           if query.narrative
             style = "margin-left: -0.5em; vertical-align: baseline; position: relative; top: 0.2em;"


### PR DESCRIPTION
When conversations are opened, the pages created should follow the same sequence as the flags in the Activity item. This means the newest should be the last opened and thus appear on the far right of the lineup. This also leaves the newest page the active one.

(I'm surprised this isn't the case as I know we have paid attention to this before.)