### PR TITLE
use site adapter prototype to get flag url

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -234,7 +234,7 @@ bind = ($item, item) ->
         for each, i in sites
           joint = if sites[i-1]?.page.date == each.page.date then "" else " "
           flags.unshift joint
-          flags.unshift h('img.remote', { title: "#{each.site}\n#{wiki.util.formatElapsedTime each.page.date}", src: "http://#{each.site}/favicon.png", attributes:  {"data-site": each.site, "data-slug": each.page.slug}})
+          flags.unshift h('img.remote', { title: "#{each.site}\n#{wiki.util.formatElapsedTime each.page.date}", src: "#{wiki.site(each.site).flag()}", attributes:  {"data-site": each.site, "data-slug": each.page.slug}})
 
 
         activityBody.push h 'div', {style: {clear: 'both'}, id: sites[0].page.slug}, [ h('div', {style: {float: 'left'}}, pageLink), h('div', {style: {textAlign: 'right'}}, [flags, h('div', {style: {float: 'right', marginRight: '-1.1em'}}, links)])]


### PR DESCRIPTION
~NOT FOR MERGING YET~

This change works with fedwiki/wiki-client#185

This update demonstrates using the wiki site adapter to get a site's flag.

![screen shot 2017-02-14 at 13 57 40](https://cloud.githubusercontent.com/assets/1552489/22931703/8f1c2f82-f2bd-11e6-9904-36d42a9b20ff.png)