### PR TITLE
add link to Recycled Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wiki-plugin-activity",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Federated Wiki - Activity Plug-in",
   "keywords": [
     "wiki",

--- a/pages/recent-changes
+++ b/pages/recent-changes
@@ -4,7 +4,7 @@
     {
       "type": "paragraph",
       "id": "435d07cf9bf34a70",
-      "text": "Here we list neighborhood pages with those most recently changed listed first. See also [[Local Changes]]."
+      "text": "Here we list neighborhood pages with those most recently changed listed first. See [[Local Changes]], [[Recycled Pages]]."
     },
     {
       "type": "activity",
@@ -97,6 +97,36 @@
         "text": "Here we list neighborhood pages with those most recently changed listed first. See also [[Local Changes]]."
       },
       "date": 1362955694011
+    },
+    {
+      "type": "edit",
+      "id": "435d07cf9bf34a70",
+      "item": {
+        "type": "paragraph",
+        "id": "435d07cf9bf34a70",
+        "text": "Here we list neighborhood pages with those most recently changed listed first. See also [[Local Changes]], [[Recycled Pages]]"
+      },
+      "date": 1508106497613
+    },
+    {
+      "type": "edit",
+      "id": "435d07cf9bf34a70",
+      "item": {
+        "type": "paragraph",
+        "id": "435d07cf9bf34a70",
+        "text": "Here we list neighborhood pages with those most recently changed listed first. See [[Local Changes]], [[Recycled Pages]]"
+      },
+      "date": 1508106649465
+    },
+    {
+      "type": "edit",
+      "id": "435d07cf9bf34a70",
+      "item": {
+        "type": "paragraph",
+        "id": "435d07cf9bf34a70",
+        "text": "Here we list neighborhood pages with those most recently changed listed first. See [[Local Changes]], [[Recycled Pages]]."
+      },
+      "date": 1508106661080
     }
   ]
 }


### PR DESCRIPTION
This is a companion to https://github.com/fedwiki/wiki-plugin-recycler/pull/2 but not required to be sequenced in any particular ways. The goal here is to offer navigation between three similar pages without requiring more than two links on any page and often only one extra link. Recent Changes carries an extra burden since it is the entry point for this navigation.

Recent Changes => Local Changes, Recycled Pages
Recycled Pages => Local Changes
Local Changes => Recent Changes


![image](https://user-images.githubusercontent.com/12127/31589995-8656afba-b1be-11e7-9b61-1f95f28a5dcc.png)

