### PR TITLE
Create factory.json

### DIFF
--- a/factory.json
+++ b/factory.json
@@ -1,0 +1,5 @@
+{
+  "name": "Activity",
+  "title": "Activity Plugin",
+  "pages": ["Recent Changes"]
+}


### PR DESCRIPTION
This pull request adds a factory.json metadata file which specifies that the hamburger menu should include the about page, Recent Changes. We don't add a category field so we won't see Activity on the Factory menu. We haven't been offering to instantiate new Activity items even though there are useful options that could be configured if we did. My thought here is that the status-quo is working ok.

This pull request depends on factory.json interpretation changes in https://github.com/fedwiki/wiki-client/pull/228