### PR TITLE
Update recent-changes

### DIFF
--- a/pages/recent-changes
+++ b/pages/recent-changes
@@ -13,7 +13,8 @@
     },
     {
       "type": "activity",
-      "id": "e9e9f102158e1382"
+      "id": "e9e9f102158e1382",
+      "text": " "
     },
     {
       "type": "paragraph",
@@ -51,7 +52,8 @@
     {
       "item": {
         "type": "activity",
-        "id": "e9e9f102158e1382"
+        "id": "e9e9f102158e1382",
+        "text": " "
       },
       "id": "e9e9f102158e1382",
       "type": "add",


### PR DESCRIPTION
Add space as markup for Activity plugin to make double-click usability trap less damaging.

Double-clicking the link to Recent Changes will fork and break the about page. This makes that less likely.