### PR TITLE
appling the 'recent changes' usability fix to the about page 

### DIFF
--- a/pages/about-activity-plugin
+++ b/pages/about-activity-plugin
@@ -8,7 +8,8 @@
     },
     {
       "type": "activity",
-      "id": "c43a88598cb67997"
+      "id": "c43a88598cb67997",
+      "text": " "
     }
   ],
   "journal": [
@@ -22,7 +23,8 @@
     {
       "item": {
         "type": "activity",
-        "id": "c43a88598cb67997"
+        "id": "c43a88598cb67997",
+        "text": " "
       },
       "id": "c43a88598cb67997",
       "type": "add",


### PR DESCRIPTION
Add space as markup for Activity plugin to make double-click usability trap less damaging.