### PR TITLE
fix issue with unexpected object() rather than array

### DIFF
--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -145,7 +145,7 @@ bind = ($item, item) ->
   rootNode = createElement tree
   $item.append rootNode
 
-  unfilteredPages = {}
+  unfilteredPages = new Map() 
   pages = {}
 
   display = (query, pages) ->
@@ -265,13 +265,13 @@ bind = ($item, item) ->
       if query.includeNeighbors or (!query.includeNeighbors and site is location.host) or site == location.host or query.rosterResults[site]
         if !(query.mine is "no" and site is location.host)
           for each in map.sitemap
-            sites = unfilteredPages[each.slug]
-            unfilteredPages[each.slug] = sites = [] unless sites?
+            sites = unfilteredPages.get(each.slug)
+            unfilteredPages.set(each.slug, sites = []) unless sites?
             if _.findIndex(sites, ['site', site]) is -1
               sites.push {site: site, page: {slug: each.slug, title: each.title, date: each.date}}
             else
               sites[_.findIndex(sites, ['site', site])] = {site: site, page: {slug: each.slug, title: each.title, date: each.date}}
-    pages = unfilteredPages
+    pages = Object.fromEntries(unfilteredPages)
     for slug, sites of pages
       sites.sort (a, b) ->
         (b.page.date || 0) - (a.page.date || 0)

--- a/client/activity.coffee
+++ b/client/activity.coffee
@@ -265,8 +265,9 @@ bind = ($item, item) ->
       if query.includeNeighbors or (!query.includeNeighbors and site is location.host) or site == location.host or query.rosterResults[site]
         if !(query.mine is "no" and site is location.host)
           for each in map.sitemap
+            if !unfilteredPages.has(each.slug)
+              unfilteredPages.set(each.slug, [])
             sites = unfilteredPages.get(each.slug)
-            unfilteredPages.set(each.slug, sites = []) unless sites?
             if _.findIndex(sites, ['site', site]) is -1
               sites.push {site: site, page: {slug: each.slug, title: each.title, date: each.date}}
             else


### PR DESCRIPTION
Having a page called 'Constructor' causes a problem with `sites = unfilteredPages.get(each.slug)` getting an `object()` rather than the expected array of sites.

Changing `unfilteredPages` to a Map, did consider [creating with `null` prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#object_with_null_prototype) but that has traps.