### PR TITLE
fix pageURL logic to not put double slash before slugs in some cases

### DIFF
--- a/src/client/activity.js
+++ b/src/client/activity.js
@@ -239,7 +239,7 @@ const bind = ($item, item) => {
 
         const pageURL =
           (sites.length === 1 && sites[0].site !== location.host) || !sites.some(i => i.site === location.host)
-            ? wiki.site(sites[0].site).getURL(`/${sites[0].page.slug}.html`)
+            ? wiki.site(sites[0].site).getURL(`${sites[0].page.slug}.html`)
             : `/${sites[0].page.slug}.html`
 
         const pageLink = h(


### PR DESCRIPTION
Currently, if a page in an activity item's rendered body is only on a remote site, then it's href gets a double slash before the slug. This doesn't break how wiki works for some reason (if you just click the link normally), but it does break the ability to open any of those links in a new tab.

I have tested this fix locally, and it seems to work in all cases.

This is how hovering over links looked before:
![image](https://github.com/user-attachments/assets/85c2eda7-f81a-473f-bb4b-db522721dc44)

And this is how they look now after my fix:
![image](https://github.com/user-attachments/assets/1cc38b0f-7405-4068-8fd5-b046b2c4f848)
