### PR TITLE
Change build scripts to chain commands with && rather than semicolons

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "Robert Best <chessscholar@gmail.com>"
   ],
   "scripts": {
-    "build": "npm run clean; npm run test; node scripts/build-client.js",
+    "build": "npm run clean && npm run test && node scripts/build-client.js",
     "clean": "rm client/activity.js client/activity.js.map",
     "prettier:format": "prettier --write './**/*.js'",
     "prettier:check": "prettier --check ./**/*.js",


### PR DESCRIPTION
This makes it more cross-platform, as command chaining with semicolons doesn't work on Windows